### PR TITLE
Fixed bug in getPlayerEntityIds().

### DIFF
--- a/mcpi/minecraft.py
+++ b/mcpi/minecraft.py
@@ -329,7 +329,9 @@ class Minecraft:
     def getPlayerEntityIds(self):
         """Get the entity ids of the connected players => [id:int]"""
         ids = self.conn.sendReceive(b"world.getPlayerIds")
-        return list(map(int, ids.split("|")))
+        if ids:
+            return list(map(int, ids.split("|")))
+        return []
 
     def getPlayerEntityId(self, name):
         """Get the entity id of the named player => [id:int]"""


### PR DESCRIPTION
When no players are online, which can happen if the script is running server side, if getPlayerEntityIds() is called it will raise an error because it cannot convert "" into an int. 
This was fixed by adding an if statement that returns a empty list if no players are online.
This was mentioned in issue #19.